### PR TITLE
Perform passive operations and validation every time

### DIFF
--- a/sprint_tool/main.py
+++ b/sprint_tool/main.py
@@ -33,13 +33,15 @@ def run():
     
             future_sprints = get_future_sprints(jira_agile_instance,
                                                 args.jira_board)
+            if len(future_sprints) == 0:
+                raise LookupError("No future sprints found")
     
             # Get the ids of the sprints we will want to close and start
             current_sprint_id = find_current_sprint_id(current_sprints,
                                                        args.sprint_name)
             next_sprint_id = find_next_sprint_id(future_sprints,
                                                  args.sprint_name)
-    
+
             new_sprint_name = find_new_sprint_name(future_sprints,
                                                    args.sprint_name)
     


### PR DESCRIPTION
The point is to make sure the state of the project is valid even when it is not
the time to roll over yet, so problems are detected before the day comes.

---

When adding projects not previously rolled by this tool, the next print might be missing causing this error.

```
Traceback (most recent call last):
  File "/home/ogondza/code/python/sprint-tool/sprint-tool-venv/bin/sprint-tool", line 33, in <module>
    sys.exit(load_entry_point('sprint-tool', 'console_scripts', 'sprint-tool')())
  File "/home/ogondza/code/python/sprint-tool/sprint_tool/main.py", line 43, in run
    new_sprint_name = find_new_sprint_name(future_sprints,
  File "/home/ogondza/code/python/sprint-tool/sprint_tool/main.py", line 278, in find_new_sprint_name
    next_sprint_number = int(sprint_numbers[-1]) + 1
IndexError: list index out of range
```

Fail with something meaningful instead.

@lyrch, PTAL. WS-aware diff https://github.com/lyrch/sprint-tool/pull/11/files?w=1